### PR TITLE
Adds "_code" class variable

### DIFF
--- a/Amazon/MCF/Model/Carrier/AmazonFulfillment.php
+++ b/Amazon/MCF/Model/Carrier/AmazonFulfillment.php
@@ -42,6 +42,7 @@ class AmazonFulfillment extends AbstractCarrier implements CarrierInterface
      * @var string
      */
     protected $code = self::CODE;
+    protected $_code = self::CODE;
 
     /**
      * @var bool


### PR DESCRIPTION
Issue #3

The pull request adds the protected class variable `Amazon\MCF\Model\CarrierAmazonFulfillment::_code`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
