### PR TITLE
Modifies conversion helper with default carrier data

### DIFF
--- a/Amazon/MCF/Helper/Conversion.php
+++ b/Amazon/MCF/Helper/Conversion.php
@@ -134,11 +134,11 @@ class Conversion extends AbstractHelper
         foreach ($items as $item) {
             $enabled = $item->getProduct()->getData('amazon_mcf_asin_enabled');
             $sku = $item->getProduct()->getData('amazon_mcf_merchant_sku');
-            if ($enabled) {
+            if ($enabled && $item->canShip()) {
                 $qty = 0;
                 $id = '';
 
-                !empty($item->getQty()) ? $qty = $item->getQty() : $qty = $item->getQtyOrdered();
+                !empty($item->getQtyToShip()) ? $qty = $item->getQtyToShip() : $qty = $item->getQtyOrdered();
                 !empty($item->getQuoteId()) ? $id = $item->getQuoteId() : $id = $item->getQuoteItemId();
 
                 $itemData = [

--- a/Amazon/MCF/Helper/Conversion.php
+++ b/Amazon/MCF/Helper/Conversion.php
@@ -203,7 +203,11 @@ class Conversion extends AbstractHelper
      */
     public function getCarrierCodeFromPackage($package)
     {
-        return $this->carriers[$package->getCarrierCode()]['carrier_code'];
+        $code = $package->getCarrierCode();
+        if (isset($this->carriers[$code]) && isset($this->carriers[$code]['carrier_code'])) {
+            return $this->carriers[code]['carrier_code'];
+        }
+        return strtolower(str_ireplace(' ', '_', $code));
     }
 
     /**
@@ -213,6 +217,10 @@ class Conversion extends AbstractHelper
      */
     public function getCarrierTitleFromPackage($package)
     {
-        return $this->carriers[$package->getCarrierCode()]['title'];
+        $code = $package->getCarrierCode();
+        if (isset($this->carriers[$code]) && isset($this->carriers[$code]['title'])) {
+            return $this->carriers[code]['title'];
+        }
+        return $code;
     }
 }

--- a/Amazon/MCF/Helper/Conversion.php
+++ b/Amazon/MCF/Helper/Conversion.php
@@ -134,11 +134,16 @@ class Conversion extends AbstractHelper
         foreach ($items as $item) {
             $enabled = $item->getProduct()->getData('amazon_mcf_asin_enabled');
             $sku = $item->getProduct()->getData('amazon_mcf_merchant_sku');
-            if ($enabled && $item->canShip()) {
+            $orderItem = ($item instanceof \Magento\Sales\Api\Data\OrderItemInterface);
+
+            // Check if order item can be shipped
+            if ($orderItem && !$item->canShip()) continue;
+
+            if ($enabled) {
                 $qty = 0;
                 $id = '';
 
-                !empty($item->getQtyToShip()) ? $qty = $item->getQtyToShip() : $qty = $item->getQtyOrdered();
+                $qty = ($orderItem ? $item->getQtyToShip() : $item->getQty());
                 !empty($item->getQuoteId()) ? $id = $item->getQuoteId() : $id = $item->getQuoteItemId();
 
                 $itemData = [

--- a/Amazon/MCF/Helper/Conversion.php
+++ b/Amazon/MCF/Helper/Conversion.php
@@ -205,7 +205,7 @@ class Conversion extends AbstractHelper
     {
         $code = $package->getCarrierCode();
         if (isset($this->carriers[$code]) && isset($this->carriers[$code]['carrier_code'])) {
-            return $this->carriers[code]['carrier_code'];
+            return $this->carriers[$code]['carrier_code'];
         }
         return strtolower(str_ireplace(' ', '_', $code));
     }
@@ -219,7 +219,7 @@ class Conversion extends AbstractHelper
     {
         $code = $package->getCarrierCode();
         if (isset($this->carriers[$code]) && isset($this->carriers[$code]['title'])) {
-            return $this->carriers[code]['title'];
+            return $this->carriers[$code]['title'];
         }
         return $code;
     }


### PR DESCRIPTION
Fix for Issue #8 

This update defaults the carrier **code** and **title** to the provided carrier code while creating a tracking number during the order update process (cron job).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
